### PR TITLE
Use whole chunk size if HTTP_CONTENT_RANGE is not provided

### DIFF
--- a/chunked_upload/views.py
+++ b/chunked_upload/views.py
@@ -179,13 +179,16 @@ class ChunkedUploadView(ChunkedUploadBaseView):
 
         content_range = request.META.get('HTTP_CONTENT_RANGE', '')
         match = self.content_range_pattern.match(content_range)
-        if not match:
-            raise ChunkedUploadError(status=http_status.HTTP_400_BAD_REQUEST,
-                                     detail='Error in request headers')
+        if match:
+            start = int(match.group('start'))
+            end = int(match.group('end'))
+            total = int(match.group('total'))
+        else:
+            # Use the whole size when HTTP_CONTENT_RANGE is not provided.
+            start = 0
+            end = chunk.size - 1
+            total = chunk.size
 
-        start = int(match.group('start'))
-        end = int(match.group('end'))
-        total = int(match.group('total'))
         chunk_size = end - start + 1
         max_bytes = self.get_max_bytes(request)
 


### PR DESCRIPTION
[Jquery File Upload](https://github.com/blueimp/jQuery-File-Upload) does not send the `HTTP_CONTENT_RANGE` header if the file is smaller then the given chunk size. This packages fails when not providing this header, so I've fixed this.

I can understand if you don't want to merge this (as this also could be fixed in JFU), but given that this package is intended to work with JFU I think this should be fixed here.