### PR TITLE
Fix python 3 compatibility in delete uploads command

### DIFF
--- a/chunked_upload/management/commands/delete_expired_uploads.py
+++ b/chunked_upload/management/commands/delete_expired_uploads.py
@@ -46,5 +46,5 @@ class Command(BaseCommand):
             # Deleting objects individually to call delete method explicitly
             chunked_upload.delete()
 
-        print '%i complete uploads were deleted.' % count[COMPLETE]
-        print '%i incomplete uploads were deleted.' % count[UPLOADING]
+        print('%i complete uploads were deleted.' % count[COMPLETE])
+        print('%i incomplete uploads were deleted.' % count[UPLOADING])


### PR DESCRIPTION
`print()` works for both Python 2 and 3 :).