### PR TITLE
Modify the upload_id field by Django builtin UUIDField

### DIFF
--- a/chunked_upload/models.py
+++ b/chunked_upload/models.py
@@ -14,12 +14,8 @@ from .constants import CHUNKED_UPLOAD_CHOICES, UPLOADING
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 
-def generate_upload_id():
-    return uuid.uuid4().hex
-
-
 def generate_filename(instance, filename):
-    filename = os.path.join(UPLOAD_PATH, instance.upload_id + '.part')
+    filename = os.path.join(UPLOAD_PATH, instance.upload_id.hex + '.part')
     return time.strftime(filename)
 
 
@@ -30,8 +26,7 @@ class BaseChunkedUpload(models.Model):
     Inherit from this model to implement your own.
     """
 
-    upload_id = models.CharField(max_length=32, unique=True, editable=False,
-                                 default=generate_upload_id)
+    upload_id = models.UUIDField(unique=True, editable=False, default=uuid.uuid4)
     file = models.FileField(max_length=255, upload_to=generate_filename,
                             storage=STORAGE)
     filename = models.CharField(max_length=255)


### PR DESCRIPTION
New in Django 1.8, there is a new field called UUIDField.

Feel free to close this for the consideration of  being compatible with the former edition.