### PR TITLE
Fix 'The 'file' attribute has no file associated with it.' on delete

### DIFF
--- a/chunked_upload/models.py
+++ b/chunked_upload/models.py
@@ -59,9 +59,10 @@ class BaseChunkedUpload(models.Model):
         return self._md5
 
     def delete(self, delete_file=True, *args, **kwargs):
-        storage, path = self.file.storage, self.file.path
+        if self.file:
+            storage, path = self.file.storage, self.file.path
         super(BaseChunkedUpload, self).delete(*args, **kwargs)
-        if delete_file:
+        if self.file and delete_file:
             storage.delete(path)
 
     def __unicode__(self):


### PR DESCRIPTION
If something goes wrong, and a ChunkedUpload object is created, but the FileField does not have an underlying file on storage then delete() is impossible. Any attempt to delete the ChunkedUpload from the DB will raise an error:

```python
   upload.delete()
  File "/home2/dtrudgian/Git/astrocyte/.venv/lib/python2.7/site-packages/chunked_upload/models.py", line 62, in delete
    storage, path = self.file.storage, self.file.path
  File "/home2/dtrudgian/Git/astrocyte/.venv/lib/python2.7/site-packages/django/db/models/fields/files.py", line 63, in _get_path
    self._require_file()
  File "/home2/dtrudgian/Git/astrocyte/.venv/lib/python2.7/site-packages/django/db/models/fields/files.py", line 46, in _require_file
    raise ValueError("The '%s' attribute has no file associated with it." % self.field.name)
ValueError: The 'file' attribute has no file associated with it.

```

This change checks to see if there is a valid file, before attempting to access file.storage, file.path and remove the file.