### PR TITLE
Adds `on_delete` argument to ForeignKey field in `BaseChunkedUpload`

### DIFF
--- a/chunked_upload/models.py
+++ b/chunked_upload/models.py
@@ -94,7 +94,8 @@ class ChunkedUpload(BaseChunkedUpload):
     To use it, set CHUNKED_UPLOAD_ABSTRACT_MODEL as True in your settings.
     """
 
-    user = models.ForeignKey(AUTH_USER_MODEL, related_name='chunked_uploads')
+    user = models.ForeignKey(AUTH_USER_MODEL, related_name='chunked_uploads',
+                             on_delete=models.CASCADE)
 
     class Meta:
         abstract = ABSTRACT_MODEL


### PR DESCRIPTION
Django 2.0 requires ForeignKey and OneToOneFields to have the
[`on_delete` argument declared explicitly](https://docs.djangoproject.com/en/2.0/releases/2.0/#features-removed-in-2-0).