### PR TITLE
fix deprecated ugettext method call for django 4

### DIFF
--- a/chunked_upload/constants.py
+++ b/chunked_upload/constants.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 class http_status:


### PR DESCRIPTION
This pull request contains a fix in the `ugettext` call in the constants.py file.
That method has been deprecated in Django 4> where the package throws errors when running the Django server.

Fixes #65 